### PR TITLE
Add tabs to Landlord home page, show properties, clean style

### DIFF
--- a/client/src/components/LandlordInfoCard.jsx
+++ b/client/src/components/LandlordInfoCard.jsx
@@ -20,7 +20,7 @@ const theme = createTheme({
 export function LandlordInfoCard(props) {
   return (
     <ThemeProvider theme={theme}>
-      <Card>
+      <Card sx={{ backgroundColor: 'lightgrey' }}>
         <Stack
           spacing={5}
           direction='row'
@@ -30,7 +30,6 @@ export function LandlordInfoCard(props) {
             variant='h3'
             sx={{ m: 3, width: 'auto', justifyContent: 'space-between', fontSize: '30px' }}
           >
-            {props.first_name} {props.last_name}
           </Typography>
           {/* <Link to={`/reviews/$/`}><Button variant='contained' sx={{m: 3}}>Is this you?</Button></Link> */}
         </Stack>

--- a/client/src/components/LandlordInfoCard.jsx
+++ b/client/src/components/LandlordInfoCard.jsx
@@ -20,15 +20,11 @@ const theme = createTheme({
 export function LandlordInfoCard(props) {
   return (
     <ThemeProvider theme={theme}>
-      <Card sx={{ backgroundColor: 'lightgrey' }}>
-        <Stack
-          spacing={5}
-          direction='row'
-          sx={{ justifyContent: 'space-between' }}
-        >
+      <Card sx={{ bgcolor: 'transparent' }}>
+        <Stack>
           <Typography
             variant='h3'
-            sx={{ m: 3, width: 'auto', justifyContent: 'space-between', fontSize: '30px' }}
+            sx={{ m: 1, width: 'auto', justifyContent: 'space-between', fontSize: '30px' }}
           >
           </Typography>
           {/* <Link to={`/reviews/$/`}><Button variant='contained' sx={{m: 3}}>Is this you?</Button></Link> */}
@@ -87,10 +83,10 @@ export function LandlordInfoCard(props) {
           <Icon>
             {props.bike_friendly ? (
               <CheckIcon
-                style={{ color: 'limeGreen', fontSize: '20px' }}
+                style={{ color: 'green', fontSize: '30px' }}
               ></CheckIcon>
             ) : (
-              <ClearIcon style={{ color: 'tomato', fontSize: '20px' }} />
+              <ClearIcon style={{ color: 'tomato', fontSize: '30px' }} />
             )}
           </Icon>
         </Stack>
@@ -103,10 +99,10 @@ export function LandlordInfoCard(props) {
           <Icon>
             {props.pet_friendly ? (
               <CheckIcon
-                style={{ color: 'limeGreen', fontSize: '20px' }}
+                style={{ color: 'limeGreen', fontSize: '30px' }}
               ></CheckIcon>
             ) : (
-              <ClearIcon style={{ color: 'tomato', fontSize: '20px' }} />
+              <ClearIcon style={{ color: 'tomato', fontSize: '30px' }} />
             )}
           </Icon>
         </Stack>

--- a/client/src/components/PropertyCard.jsx
+++ b/client/src/components/PropertyCard.jsx
@@ -25,9 +25,12 @@ export function PropertyCard(props) {
           sx={{ m: 1, width: 'auto', justifyContent: 'space-between', fontSize: '30px' }}
         > 
           <Stack>
-            <h5>{props.city},{props.state}</h5>
-            {props.street_num}{props.street} 
-            {/* <Link to={`/reviews/$/`}><Button variant='contained' sx={{m: 3}}>Is this you?</Button></Link> */}
+            <div>
+              <h5>{props.city},{props.state}</h5>
+              <Typography variant='h6'>
+                {props.street_num}{props.street} 
+              </Typography>
+            </div>
             <div>
               <NavLink
                 to='/map'

--- a/client/src/components/PropertyCard.jsx
+++ b/client/src/components/PropertyCard.jsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import { Stack } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
 import Button from '@mui/material/Button';
+import { NavLink } from 'react-router-dom';
 
 
 import '../index.css';
@@ -28,7 +29,11 @@ export function PropertyCard(props) {
             {props.street_num}{props.street} 
             {/* <Link to={`/reviews/$/`}><Button variant='contained' sx={{m: 3}}>Is this you?</Button></Link> */}
             <div>
-              <Button sx={{float:'right', fontSize:'20px', color: 'tomato'}}>Open in Map</Button>
+              <NavLink
+                to='/map'
+              >
+                <Button sx={{float:'right', fontSize:'20px', color: 'tomato'}}>Open in Map</Button>
+              </NavLink>
             </div>
           </Stack>
         </Typography>

--- a/client/src/components/PropertyCard.jsx
+++ b/client/src/components/PropertyCard.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import Typography from '@mui/material/Typography';
+import { Stack } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+
+
+import '../index.css';
+import { ThemeProvider } from '@emotion/react';
+
+const theme = createTheme({
+  typography: {
+    fontFamily: ['Nunito']
+  },
+});
+
+export function PropertyCard(props) {
+  return (
+    <ThemeProvider theme={theme}>
+      <Card sx={{ bgcolor: 'transparent' }}>
+        <Typography
+          variant='h3'
+          sx={{ m: 1, width: 'auto', justifyContent: 'space-between', fontSize: '30px' }}
+        > 
+          <Stack>
+            <h5>{props.city},{props.state}</h5>
+            {props.street_num}{props.street} 
+            {/* <Link to={`/reviews/$/`}><Button variant='contained' sx={{m: 3}}>Is this you?</Button></Link> */}
+            <div>
+              <Button sx={{float:'right', fontSize:'20px', color: 'tomato'}}>Open in Map</Button>
+            </div>
+          </Stack>
+        </Typography>
+
+      </Card>
+    </ThemeProvider>
+  );
+}

--- a/client/src/components/Review.jsx
+++ b/client/src/components/Review.jsx
@@ -149,7 +149,7 @@ export function Review(props) {
             <Icon>
               {props.bike_friendly ? (
                 <CheckIcon
-                  style={{ color: 'limeGreen', fontSize: '20px' }}
+                  style={{ color: 'green', fontSize: '20px' }}
                 ></CheckIcon>
               ) : (
                 <ClearIcon style={{ color: 'tomato', fontSize: '20px' }} />

--- a/client/src/components/Review.jsx
+++ b/client/src/components/Review.jsx
@@ -20,7 +20,7 @@ export function Review(props) {
   const [description, setDescription] = useState(props.description);
 
   const { user } = useContext(UserContext);
-  
+
   const handleSave = async () => {
     try {
       const { status, data } = await axios.put(`/reviews/${props._id}`, { title, description });
@@ -68,7 +68,7 @@ export function Review(props) {
                   Posted by: {props.username}
                 </Typography>
               </div>
-              {user.username === props.username && (
+              {user?.username === props.username && (
                 <div
                   className='userActions'
                   style={{

--- a/client/src/components/Review.jsx
+++ b/client/src/components/Review.jsx
@@ -20,7 +20,7 @@ export function Review(props) {
   const [description, setDescription] = useState(props.description);
 
   const { user } = useContext(UserContext);
-
+  
   const handleSave = async () => {
     try {
       const { status, data } = await axios.put(`/reviews/${props._id}`, { title, description });

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -121,10 +121,11 @@ export default function ProfilePage() {
           <Stack className='LandlordInfo' sx={{ pb: 5, pl: 5 }} direction='row' justifyContent='space-around'>
             <Stack>
               <Card sx={{ minWidth: 275 }}>
-                <CardContent>
+                <CardContent sx={{ml: '50px', fontSize: '20px'}}>
                   <div className='ProfilePicture'>
                     <img style={{ height: '150px' }} src={`/images/${landlordData.profile_pic}`} />
                   </div>
+                  {landlordData.first_name} {landlordData.last_name}
                 </CardContent>
               </Card>
               <Card>
@@ -176,7 +177,7 @@ export default function ProfilePage() {
               <Stack sx={{ alignItems: 'center', p: 1, m: 1, }}>
                 <FormControl sx={{ minWidth: 120 }} size='small' >
                   <InputLabel>Sort by</InputLabel>
-                  <Select value={reviewFilter} label='Sort by' onChange={handleFilter}>
+                  <Select MenuProps={{ sx: { '&& .MuiPaper-root': { backgroundColor: 'lightgrey' }}}} value={reviewFilter} label='Sort by' onChange={handleFilter}>
                     <MenuItem value={'helpful'}>Most Helpful</MenuItem>
                     <MenuItem value={'critical'}>Most Critical</MenuItem>
                     <MenuItem value={'recent'}>Most Recent</MenuItem>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef, useContext } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import axios from 'axios';
-
-import { FormControl, MenuItem, Select, InputLabel } from '@mui/material';
+import { FormControl, MenuItem, Select, InputLabel, Tab, Tabs } from '@mui/material';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -32,6 +31,7 @@ export default function ProfilePage() {
   const [reviewData, setReviewData] = useState([]);
   const [reviewFilter, setReviewFilter] = useState('helpful');
   const { user } = useContext(UserContext);
+  const [currentTab, setCurrentTab] = useState(0);
 
   const { landlord_id: landlordId } = useParams();
   const mounted = useRef(true);
@@ -113,6 +113,12 @@ export default function ProfilePage() {
     getReviews();
   };
 
+  const handleTabChange = (e, newValue) => {
+    setCurrentTab(newValue);
+  };
+
+  console.log(landlordData)
+
   return (
     <ThemeProvider theme={tomatopalette}>
       <div id='profileBackground'
@@ -137,7 +143,7 @@ export default function ProfilePage() {
                           <ListItemIcon>
                             <EmailIcon />
                           </ListItemIcon>
-                          <ListItemText primary='Email' />
+                          <ListItemText primary={landlordData.email} />
                           <ListItemText />
                         </ListItemButton>
                       </ListItem>
@@ -150,14 +156,6 @@ export default function ProfilePage() {
                         </ListItemButton>
                       </ListItem>
                     </List>
-                    <ListItem disablePadding>
-                      <ListItemButton>
-                        <ListItemIcon>
-                          <ApartmentIcon />
-                        </ListItemIcon>
-                        <ListItemText primary='Office Location' />
-                      </ListItemButton>
-                    </ListItem>
                   </nav>
                 </Box>
               </Card>
@@ -166,15 +164,34 @@ export default function ProfilePage() {
               <LandlordInfoCard {...landlordData} />
             </Stack>
           </Stack>
+          <Tabs
+            textColor="inherit"
+            variant="fullWidth"
+            TabIndicatorProps={{
+              style: {
+                backgroundColor: '#df4f35ea'
+              }
+            }}
+            value={currentTab}
+            onChange={handleTabChange}
+            sx={{mt:'35px'}}
+          >
+            <Tab label="About" />
+            <Tab label="Reviews" />
+            <Tab label="All Properties" />
+          </Tabs>
+          {currentTab === 0 &&
+            <div style={{ alignItems: 'center', marginTop: '30px'}}>
+              {landlordData.description}
+            </div>
+          }
+          {currentTab === 1 && 
           <Container>
-            <Stack spacing={2} direction='row' >
-              <Typography variant='h3' gutterBottom component='div'>
-                Reviews
-              </Typography>
-              <Stack sx={{ alignItems: 'center', p: 1, m: 1, }}>
+            <Stack spacing={2} direction='row' sx={{marginTop: '30px'}} >
+              <Stack>
                 {user && <Button variant='contained' onClick={handleReview}>Create Review</Button>}
               </Stack>
-              <Stack sx={{ alignItems: 'center', p: 1, m: 1, }}>
+              <Stack>
                 <FormControl sx={{ minWidth: 120 }} size='small' >
                   <InputLabel>Sort by</InputLabel>
                   <Select MenuProps={{ sx: { '&& .MuiPaper-root': { backgroundColor: 'lightgrey' }}}} value={reviewFilter} label='Sort by' onChange={handleFilter}>
@@ -185,9 +202,7 @@ export default function ProfilePage() {
                 </FormControl>
               </Stack>
             </Stack>
-          </Container>
-          <Container>
-            <Stack>
+            <Stack >
               <div>
                 {reviewData.map((eachReview, i) => (
                   <Review
@@ -198,9 +213,9 @@ export default function ProfilePage() {
                   />
                 ))}
               </div>
-            </Stack>
-          </Container>
-        </Container>
+            </Stack> 
+          </Container> }
+        </Container> 
       </div>
     </ThemeProvider>
   );

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -24,6 +24,7 @@ import tomatopalette from '../components/tomatopalette';
 import { Review } from '../components/Review';
 import { LandlordInfoCard } from '../components/LandlordInfoCard';
 import UserContext from '../hooks/userContext';
+import { PropertyCard } from '../components/PropertyCard';
 
 export default function ProfilePage() {
   const navigate = useNavigate();
@@ -116,8 +117,6 @@ export default function ProfilePage() {
   const handleTabChange = (e, newValue) => {
     setCurrentTab(newValue);
   };
-
-  console.log(landlordData)
 
   return (
     <ThemeProvider theme={tomatopalette}>
@@ -215,6 +214,20 @@ export default function ProfilePage() {
               </div>
             </Stack> 
           </Container> }
+          {currentTab === 2 &&
+          <Stack sx={{marginTop:'20px'}}>
+            <div>
+              {landlordData.properties.map((eachProperty, i) => (
+                <PropertyCard
+                  key={i}
+                  {...eachProperty}
+
+                />
+              ))}
+            </div>
+          </Stack> 
+
+          }
         </Container> 
       </div>
     </ThemeProvider>

--- a/server/controllers/landlordController.js
+++ b/server/controllers/landlordController.js
@@ -5,7 +5,7 @@ const landlordController = {};
 
 landlordController.getById = async (req, res, next) => {
   const landlordQuery = {
-    text: `SELECT l.*, u.first_name, u.last_name, u.username, u.email, u.profile_pic 
+    text: `SELECT l.*, u.first_name, u.last_name, u.username, u.email, u.description, u.profile_pic 
     FROM landlords l LEFT JOIN users u ON u._id = l._id WHERE l._id = $1`,
     values: [req.params.landlordId]
   };


### PR DESCRIPTION
- Add tabs to Landlord home page
- Show all properties of a landlord
- Clean up the style
- Open in Map button takes user to Map section

<img width="1328" alt="Screen Shot 2022-04-19 at 9 54 26 PM" src="https://user-images.githubusercontent.com/44415609/164153190-07929e8c-3f72-44fd-bfd3-83e75c13d31b.png">
<img width="1325" alt="Screen Shot 2022-04-19 at 9 54 41 PM" src="https://user-images.githubusercontent.com/44415609/164153217-09c7fada-bc6c-4352-bd2d-960b0b89972d.png">
<img width="1359" alt="Screen Shot 2022-04-19 at 10 07 01 PM" src="https://user-images.githubusercontent.com/44415609/164154485-d837b73b-1a63-482c-8630-f8b6977b4a76.png">

